### PR TITLE
feat(30-binary-numbers)

### DIFF
--- a/domains/tutorials/30-days-of-code/30-binary-numbers/main.go
+++ b/domains/tutorials/30-days-of-code/30-binary-numbers/main.go
@@ -5,23 +5,27 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 )
 
-func BinaryNumber(n int32) int32 {
+func BinaryNumber(n int32) int {
 	s := fmt.Sprintf("%b", n)
 
-	out := s[:len(s)-1]
+	var stack []int
 
-	count := make(map[rune]int32)
-
-	for _, v := range out {
-		if v == '1' {
-			count[v]++
+	c := 0
+	for i, v := range s {
+		if v == '0' || i == len(s)-1 {
+			stack = append(stack, c)
+			c = 0
+		} else {
+			c++
 		}
 	}
-	return count['1']
+	sort.Ints(stack)
+	return stack[len(stack)-1]
 }
 
 func main() {

--- a/domains/tutorials/30-days-of-code/30-binary-numbers/main.go
+++ b/domains/tutorials/30-days-of-code/30-binary-numbers/main.go
@@ -17,11 +17,14 @@ func BinaryNumber(n int32) int {
 
 	c := 0
 	for i, v := range s {
-		if v == '0' || i == len(s)-1 {
+		if v == '1' {
+			c++
+			if i == len(s)-1 {
+				stack = append(stack, c)
+			}
+		} else {
 			stack = append(stack, c)
 			c = 0
-		} else {
-			c++
 		}
 	}
 	sort.Ints(stack)

--- a/domains/tutorials/30-days-of-code/30-binary-numbers/main.go
+++ b/domains/tutorials/30-days-of-code/30-binary-numbers/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func BinaryNumber(n int32) int32 {
+	s := fmt.Sprintf("%b", n)
+
+	out := s[:len(s)-1]
+
+	count := make(map[rune]int32)
+
+	for _, v := range out {
+		if v == '1' {
+			count[v]++
+		}
+	}
+	return count['1']
+}
+
+func main() {
+	reader := bufio.NewReaderSize(os.Stdin, 1024*1024)
+
+	nTemp, err := strconv.ParseInt(readLine(reader), 10, 64)
+	checkError(err)
+	n := int32(nTemp)
+	fmt.Print(BinaryNumber(n))
+}
+
+func readLine(reader *bufio.Reader) string {
+	str, _, err := reader.ReadLine()
+	if err == io.EOF {
+		return ""
+	}
+
+	return strings.TrimRight(string(str), "\r\n")
+}
+
+func checkError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/domains/tutorials/30-days-of-code/30-binary-numbers/main_test.go
+++ b/domains/tutorials/30-days-of-code/30-binary-numbers/main_test.go
@@ -13,7 +13,8 @@ var cases = []struct {
 	{id: 1, input: 5, want: 1},
 	{id: 2, input: 13, want: 2},
 	{id: 3, input: 100000, want: 2},
-	{id: 4, input: 99999, want: 4},
+	{id: 4, input: 99999, want: 5},
+	{id: 5, input: 439, want: 3},
 }
 
 func TestBinaryNumber(t *testing.T) {

--- a/domains/tutorials/30-days-of-code/30-binary-numbers/main_test.go
+++ b/domains/tutorials/30-days-of-code/30-binary-numbers/main_test.go
@@ -15,6 +15,11 @@ var cases = []struct {
 	{id: 3, input: 100000, want: 2},
 	{id: 4, input: 99999, want: 5},
 	{id: 5, input: 439, want: 3},
+	{id: 6, input: 951, want: 3},
+	{id: 7, input: 1911, want: 3},
+	{id: 8, input: 65535, want: 16},
+	{id: 9, input: 524283, want: 16},
+	{id: 10, input: 524275, want: 15},
 }
 
 func TestBinaryNumber(t *testing.T) {

--- a/domains/tutorials/30-days-of-code/30-binary-numbers/main_test.go
+++ b/domains/tutorials/30-days-of-code/30-binary-numbers/main_test.go
@@ -8,10 +8,12 @@ import (
 var cases = []struct {
 	id    int
 	input int32
-	want  int32
+	want  int
 }{
 	{id: 1, input: 5, want: 1},
 	{id: 2, input: 13, want: 2},
+	{id: 3, input: 100000, want: 2},
+	{id: 4, input: 99999, want: 4},
 }
 
 func TestBinaryNumber(t *testing.T) {

--- a/domains/tutorials/30-days-of-code/30-binary-numbers/main_test.go
+++ b/domains/tutorials/30-days-of-code/30-binary-numbers/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+var cases = []struct {
+	id    int
+	input int32
+	want  int32
+}{
+	{id: 1, input: 5, want: 1},
+	{id: 2, input: 13, want: 2},
+}
+
+func TestBinaryNumber(t *testing.T) {
+	for _, tt := range cases {
+		t.Run(fmt.Sprint(tt.id), func(t *testing.T) {
+			got := BinaryNumber(tt.input)
+			if got != tt.want {
+				t.Errorf("%d, want: %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
##  first submit version
- golangに2進数リテラルはないので、`fmt.Sprintf("%b", n)` を使う
- 連続する1の個数を積み上げるstackをスライスで作成
- 2進数にした値を左からループ
   - 1ならば、カウンターcをインクリメント
      - 最後のループならスタックにカウンターCを積み上げる
   - 上記以外はカウンターcを積み上げ、カウンターを初期化
- 最後にスタックをソート
- ソートして一番最後の配列が連続した1の最大数となるのでそれを返す